### PR TITLE
Update yarn version and node version for circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,9 @@
 machine:
   environment:
-    YARN_VERSION: 0.22.0
+    YARN_VERSION: 1.3.2
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   node:
-    version: 7
+    version: 8.9.3
 dependencies:
   pre:
     - |


### PR DESCRIPTION
Updated yarn version to 1.3.2 and node version to 8.9.3 for circle CI